### PR TITLE
fix gatsby-theme-wordpress-gutenberg: prevent map empty innerBlocks

### DIFF
--- a/packages/gatsby-theme-wordpress-gutenberg/gatsby-node.js
+++ b/packages/gatsby-theme-wordpress-gutenberg/gatsby-node.js
@@ -184,11 +184,13 @@ const visitBlocks = async ({ blocks, visitor }) => {
     innerBlocksLevel = Math.max(currentInnerBlocksLevel, innerBlocksLevel)
     const visitedBlock = await visitor({ block: innerBlock })
 
-    await Promise.all(
-      visitedBlock.innerBlocks.map(async innerBlock => {
-        await visitInnerBlock({ innerBlock, currentInnerBlocksLevel: currentInnerBlocksLevel + 1 })
-      })
-    )
+    if (visitedBlock.innerBlocks) {
+      await Promise.all(
+        visitedBlock.innerBlocks.map(async innerBlock => {
+          await visitInnerBlock({ innerBlock, currentInnerBlocksLevel: currentInnerBlocksLevel + 1 })
+        })
+      )
+    }
   }
 
   await Promise.all(


### PR DESCRIPTION
When I'm using nested columns, I got:
<img width="490" alt="Screenshot at Nov 24 12-43-18" src="https://user-images.githubusercontent.com/10927960/100091391-d7f1a300-2e54-11eb-8130-c859e7d7c721.png">
I added a condition to prevent that.
